### PR TITLE
Fix Block Notify

### DIFF
--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -38,7 +38,7 @@ var BlockTemplate = module.exports = function BlockTemplate(jobId, rpcData, pool
     this.rpcData = rpcData;
     this.jobId = jobId;
 
-
+    var target = rpcData.target || rpcData._target;
     this.target = rpcData.target ?
         bignum(rpcData.target, 16) :
         util.bignumFromBitsHex(rpcData.bits);

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -307,6 +307,8 @@ var pool = module.exports = function pool(options, authorizeFn){
         _this.auxes[aux].daemon.cmd('getauxblock',
             [_this.auxes[aux].rpcData.hash, auxpow.toString('hex')],
             function(results) {
+                //console.log(results);
+                //console.log(_this.auxes[aux]);
                 for (var i = 0; i < results.length; i++){
                     var result = results[i];
                     if(result.error && result.error !== null) {
@@ -319,7 +321,7 @@ var pool = module.exports = function pool(options, authorizeFn){
                         }
                     }
                 }
-                emitLog('Submitted AuxBlock successfully to the '+_this.auxes[aux].name+' daemon instance(s) with BlockHash: '+ _this.auxes[aux].rpcData.hash);
+                emitInfoLog('Submitted auxiliary block successfully to the '+_this.auxes[aux].name+' daemon instance(s) with BlockHash: '+ _this.auxes[aux].rpcData.hash);
                 callback(_this.auxes[aux].rpcData.hash, aux);
             });
     }
@@ -383,7 +385,7 @@ var pool = module.exports = function pool(options, authorizeFn){
                           emitErrorLog('Some error occured: ' + JSON.stringify(cmdError));
                         }
                         else {
-                        _this.emit('block', options.auxes[aux].symbol, height, hash, tx, cmdResponse.details[0].amount, shareData.difficulty, shareData.worker);
+                        _this.emit('auxblock', options.auxes[aux].symbol, height, hash, tx, cmdResponse.details[0].amount, shareData.difficulty, shareData.worker);
                         }
                     });
                     UpdateAuxes();
@@ -499,9 +501,9 @@ var pool = module.exports = function pool(options, authorizeFn){
             ['getmininginfo', []],
             ['submitblock', []]
         ];
-
         _this.daemon.batchCmd(batchRpcCalls, function(error, results){
             if (error || !results){
+                console.log(results)
                 emitErrorLog('Could not start pool, error with init batch RPC call: ' + JSON.stringify(error));
                 return;
             }
@@ -512,9 +514,9 @@ var pool = module.exports = function pool(options, authorizeFn){
                 var rpcCall = batchRpcCalls[i][0];
                 var r = results[i];
                 rpcResults[rpcCall] = r.result || r.error;
-
                 if (rpcCall !== 'submitblock' && (r.error || !r.result)){
                     emitErrorLog('Could not start pool, error with init RPC ' + rpcCall + ' - ' + JSON.stringify(r.error));
+                    console.log(rpcResults[rpcCall])
                     return;
                 }
             }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -762,11 +762,13 @@ var pool = module.exports = function pool(options, authorizeFn){
     **/
     this.processBlockNotify = function(blockHash, sourceTrigger) {
         emitLog('Block notification via ' + sourceTrigger);
-        if (typeof(_this.jobManager.currentJob) !== 'undefined' && blockHash !== _this.jobManager.currentJob.rpcData.previousblockhash){
-            GetBlockTemplate(function(error, result){
-                if (error)
-                    emitErrorLog('Block notify error getting block template for ' + options.coin.name);
-            });
+        if (typeof(_this.jobManager) !== 'undefined'){
+            if (typeof(_this.jobManager.currentJob) !== 'undefined' && blockHash !== _this.jobManager.currentJob.rpcData.previousblockhash){
+                GetBlockTemplate(function(error, result){
+                    if (error)
+                        emitErrorLog('Block notify error getting block template for ' + options.coin.name);
+                });
+            }
         }
     };
 


### PR DESCRIPTION
This commit fixes the block notification. If a job manager hasn't started and a new notification comes into the pool. It crashes the pool worker.

This also fixes the block notification and entry into the database. After this update Auxiliary blocks will be correctly tracked in the database.
